### PR TITLE
Run bot in a loop using alpine bash

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,8 @@ RUN CGO_ENABLED=0 GOOS=linux go build -a -installsuffix cgo -o $APP/main $APP/ma
 
 # ------------------- Cut Here ------------------ #
 
-FROM scratch
+FROM alpine
 
 COPY --from=builder /go/traze-golang-bot/main /
-ENTRYPOINT ["/main"]
+ENTRYPOINT ["/bin/sh"]
+CMD ["-c", "while true; do /main; done"]


### PR DESCRIPTION
This allows for long running containers that do not cause crash loop backoffs in openshift.